### PR TITLE
Fix asset paths and update site metadata

### DIFF
--- a/docs/coremeta4cat-users.md
+++ b/docs/coremeta4cat-users.md
@@ -9,7 +9,7 @@ This page lists projects, data repositories, and communities that have adopted C
 
 <div style="text-align: center;">
     <a>
-    <img src="/CoreMeta4Cat/images/CoreMeta4Cat_Picture.png" alt="CoreMeta4Cat logo" style="width: 40%;">
+    <img src="images/CoreMeta4Cat_Picture.png" alt="CoreMeta4Cat logo" style="width: 40%;">
     </a>
 </div>
 
@@ -19,7 +19,7 @@ This page lists projects, data repositories, and communities that have adopted C
 
 <div style="text-align: center;">
     <a>
-    <img src="/CoreMeta4Cat/images/nfdi4cat-logo.png" alt="nfdi4cat-logo" style="width: 40%;">
+    <img src="images/nfdi4cat-logo.png" alt="nfdi4cat-logo" style="width: 40%;">
     </a>
 </div>
 

--- a/docs/design-patterns.md
+++ b/docs/design-patterns.md
@@ -9,7 +9,7 @@ This page explains the key structural decisions behind CoreMeta4Cat — how the 
 
 <div style="text-align: center;">
     <a>
-    <img src="/images/CoreMeta4Cat_Picture.png" alt="CoreMeta4Cat logo" style="width: 40%;">
+    <img src="images/CoreMeta4Cat_Picture.png" alt="CoreMeta4Cat logo" style="width: 40%;">
     </a>
 </div>
 ---

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,7 +9,7 @@ Adopting a new metadata standard does not have to mean changing how you work ove
 
 <div style="text-align: center;">
     <a>
-    <img src="/images/CoreMeta4Cat_Picture.png" alt="CoreMeta4Cat logo" style="width: 40%;">
+    <img src="images/CoreMeta4Cat_Picture.png" alt="CoreMeta4Cat logo" style="width: 40%;">
     </a>
 </div>
 
@@ -40,7 +40,7 @@ Level 4 ──► Validate records against the full CoreMeta4Cat schema
 To help you understand which terms exist and how they relate to each other, CoreMeta4Cat provides a reference Excel workbook. This workbook is **not a data entry form to fill in** — it is a structured overview of the CoreMeta4Cat vocabulary hierarchy, organised by data class, that you can use as a lookup reference when designing or annotating your own data sheets.
 
 <div style="text-align: center; margin: 1.5em 0;">
-  <a href="../assets/coremeta4cat_vocabulary.xlsx"
+  <a href="assets/coremeta4cat_vocabulary.xlsx"
      style="display: inline-block; padding: 0.7em 1.6em; background: #1976d2; color: white;
             border-radius: 4px; text-decoration: none; font-weight: bold;">
     ⬇ Download the CoreMeta4Cat vocabulary reference workbook

--- a/docs/how-to-extend.md
+++ b/docs/how-to-extend.md
@@ -9,7 +9,7 @@ This page explains how to add new entries to the CoreMeta4Cat schema — new pre
 
 <div style="text-align: center;">
     <a>
-    <img src="/images/CoreMeta4Cat_Picture.png" alt="CoreMeta4Cat logo" style="width: 40%;">
+    <img src="images/CoreMeta4Cat_Picture.png" alt="CoreMeta4Cat logo" style="width: 40%;">
     </a>
 </div>
 

--- a/docs/schema/coremeta4cat.yaml
+++ b/docs/schema/coremeta4cat.yaml
@@ -17420,7 +17420,7 @@ classes:
     class_uri: qudt:Quantity
 metamodel_version: 1.7.0
 source_file: coremeta4cat.yaml
-source_file_date: '2026-04-23T21:51:58'
+source_file_date: '2026-04-27T16:40:09'
 source_file_size: 6739
-generation_date: '2026-04-23T22:47:01'
+generation_date: '2026-04-27T17:47:17'
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,7 +12,7 @@ theme:
     - navigation.instant
     - navigation.instant.progress
     - navigation.tracking
-  logo: /images/CoreMeta4Cat_Picture.png
+  logo: images/CoreMeta4Cat_Picture.png
 
 # for adding extra css/js see https://www.mkdocs.org/user-guide/customizing-your-theme/
 
@@ -61,8 +61,9 @@ exclude_docs: |
 extra_css:
   - stylesheets//no-details-box.css
 
-site_url: https://HendrikBorgelt.github.io/CoreMeta4Cat
-repo_url: https://github.com/HendrikBorgelt/CoreMeta4Cat
+site_url: https://nfdi4cat.github.io/CoreMeta4Cat
+repo_url: https://github.com/nfdi4cat/CoreMeta4Cat
+use_directory_urls: true
 
 # enable version selector for multi-version support
 extra:

--- a/scripts/generate_schema_docs.py
+++ b/scripts/generate_schema_docs.py
@@ -355,7 +355,7 @@ def generate_markdown_for_main_class(schema: dict, main_class: str, output_file:
     if class_uri:
         md += f"**CURIE:** [`{class_uri}`]({class_uri})\n\n"
 
-    md += (f'<iframe\n    src="/assets/metadata_{main_class.lower()}_hierarchy.html"\n'
+    md += (f'<iframe\n    src="assets/metadata_{main_class.lower()}_hierarchy.html"\n'
            f'    width="100%"\n    height= "470vh"\n'
            f'    style="border: 2px solid #5C88DA; background-color: #F0F8FF;\n    "\n'
            f'    allowfullscreen\n></iframe>')


### PR DESCRIPTION
Convert absolute asset/image links to relative paths across documentation and the docs generator so images and iframes load correctly (docs/*.md, scripts/generate_schema_docs.py). Update mkdocs.yml logo path, site_url and repo_url and enable use_directory_urls. Also update schema metadata timestamps in docs/schema/coremeta4cat.yaml.