### PR TITLE
Fix excel_inbox.yaml failing on every fork PR that touches inbox/

### DIFF
--- a/.github/workflows/excel_inbox.yaml
+++ b/.github/workflows/excel_inbox.yaml
@@ -79,6 +79,11 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 1
           persist-credentials: false
+          # actions/checkout@v7 refuses fork checkouts under pull_request_target
+          # by default (anti "pwn request" guard). Safe to opt in here: this
+          # checkout is read-only data (the xlsx is never executed) and every
+          # script that actually runs is checked out from main below.
+          allow-unsafe-pr-checkout: true
 
       - name: Check out main branch into _main_branch/
         # Always run OUR scripts from main — never from the PR.
@@ -268,6 +273,8 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
           persist-credentials: true
+          # See the apply-inbox job for why this opt-in is safe here.
+          allow-unsafe-pr-checkout: true
 
       - name: Check out main branch into _main_branch/
         uses: actions/checkout@v7.0.0


### PR DESCRIPTION
## Summary

`excel_inbox.yaml` currently fails at the very first checkout step for **any** PR from a fork that touches `inbox/**` — regardless of whether an Excel file is actually present or contains errors.

`actions/checkout@v7` added a default guard that refuses to check out a fork's code under a `pull_request_target` event (anti "pwn request" protection) unless the workflow explicitly opts in with `allow-unsafe-pr-checkout: true`. This workflow is pinned to `@v7.0.0` and relies on exactly this fork-checkout pattern by design — it's the documented, security-reviewed way to read a contributor's `inbox/coremeta4cat_vocabulary.xlsx` as data without ever executing their code, with every actual script run from a separate `main`-branch checkout (`_main_branch/`). Without the opt-in, the checkout fails before the workflow ever reaches the "does an Excel file even exist" check, so PRs that only touch something like `inbox/README.md` fail too, not just genuine (and possibly invalid) Excel submissions.

## Confirmation

Reproduced live on [nfdi4cat/CoreMeta4Cat#120](https://github.com/nfdi4cat/CoreMeta4Cat/pull/120): a commit there only edits `inbox/README.md`, which was enough to trigger `excel_inbox.yaml`, and it failed at the "Check out PR branch (fork-safe)" step with:

```
Refusing to check out fork pull request code from a 'pull_request_target' workflow. This workflow runs with the base repository's GITHUB_TOKEN, secrets, default-branch cache scope, and runner access. ...
```

## Fix

Add `allow-unsafe-pr-checkout: true` to the two "Check out PR branch (fork-safe)" steps (`apply-inbox` and `finish` jobs). This is the intended opt-in, not a workaround — the workflow's own design already guarantees the fork's code is only ever read as data, never executed.

## Test plan

- [x] YAML parses correctly
- [ ] Confirm a fork PR touching `inbox/**` (with or without the Excel file present) now runs past the checkout step