### PR TITLE
Add a dev-branch download button alongside the version-specific workbook

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -40,11 +40,17 @@ Level 4 ──► Validate records against the full CoreMeta4Cat schema
 To help you understand which terms exist and how they relate to each other, CoreMeta4Cat provides a reference Excel workbook. This workbook is **not a data entry form to fill in** — it is a structured overview of the CoreMeta4Cat vocabulary hierarchy, organised by data class, that you can use as a lookup reference when designing or annotating your own data sheets.
 
 <div style="text-align: center; margin: 1.5em 0;">
-  <a href="../assets/coremeta4cat_vocabulary.xlsx"
+  <a href="https://nfdi4cat.github.io/CoreMeta4Cat/dev/assets/coremeta4cat_vocabulary.xlsx"
      style="display: inline-block; padding: 0.7em 1.6em; background: #1976d2; color: white;
             border-radius: 4px; text-decoration: none; font-weight: bold;">
-    ⬇ Download the CoreMeta4Cat vocabulary reference workbook
+    ⬇ Download the CoreMeta4Cat vocabulary reference workbook (dev)
   </a>
+  <p style="margin: 10px 0 0; font-size: 0.85em; opacity: 0.7;">
+    Always up to date with the latest schema.
+  </p>
+  <p style="margin: 14px 0 0; font-size: 0.85em;">
+    <a href="../assets/coremeta4cat_vocabulary.xlsx">Looking for the workbook matching this version of the docs instead?</a>
+  </p>
 </div>
 
 The workbook has five sheets:


### PR DESCRIPTION
## Summary

Follow-up to #120, which was already merged before this commit was pushed to that branch — re-opening it as its own PR.

The vocabulary workbook download previously linked only to the version-specific copy (`../assets/coremeta4cat_vocabulary.xlsx`), which can lag behind the schema between releases. Adds a second, prominent button pointing at the `dev` build (always up to date), and keeps the version-specific link as a quiet secondary option — newcomers land on the current schema by default, while people who specifically need the version matching these docs can still find it.

## Test plan

- [x] Verified rendering locally via `mkdocs serve`
- [ ] Confirm the docs-preview build workflow passes on this PR