### PR TITLE
Update .gitignore to remove examples output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # generated part of documentation
 /docs/elements/**/*.md
 # linkml-run-examples output (not useful to have in git in its current form)
-/examples/output/
 
 # Derived schemas, generated from the schema.yaml
 tmp/


### PR DESCRIPTION
Remove examples output directory from .gitignore